### PR TITLE
Enable access to Role membership via the Addon

### DIFF
--- a/addon/services/keycloak-session.js
+++ b/addon/services/keycloak-session.js
@@ -156,6 +156,14 @@ export default Service.extend({
 
   tokenParsed: computed('timestamp', () => Application.keycloak.tokenParsed),
 
+  hasRealmRole(role) {
+    return Application.keycloak.hasRealmRole(role);
+  },
+
+  hasResourceRole(role, resource) { //If resource is null then clientId is used
+    return Application.keycloak.hasResourceRole(role, resource);
+  },
+  
   updateToken() {
 
     // debug(`Keycloak session :: updateToken`);


### PR DESCRIPTION
Please add these two functions to the base fork as they are useful in determining user permissions from their Keycloak profile.
For Resource Roles, passing a resource value of null will use the logged in clientId by default.

e.g. to hide or display editable fields in a template, add this to the component:
```
export default Component.extend({
  session: service('keycloak-session'),
  hasReadWritePermission: computed('session', function() {
    return this.get('session').hasResourceRole('ReadWrite', null);
  }).
....
});
```
and in the Component Template:
```
{{#if hasReadWritePermission}}
  {{input ...}}
{{else}}
  <p>...</p>
{{/if}}
```
Thanks
Adrian Flynn