### PR TITLE
Added silentCheckSsoRedirectUri init property

### DIFF
--- a/addon/services/keycloak-session.ts
+++ b/addon/services/keycloak-session.ts
@@ -131,7 +131,7 @@ export default class KeycloakSessionService extends Service implements KeycloakA
    * @property enableLogging
    * @type {boolean}
    */
-  enableLogging?: string;
+  enableLogging?: boolean;
 
   /**
    * Keycloak.login() option.
@@ -191,7 +191,7 @@ export default class KeycloakSessionService extends Service implements KeycloakA
       console.debug('KeycloakSessionService :: init');
     }
 
-    let options: KeycloakInitOptions = this.getProperties('onLoad', 'responseMode', 'checkLoginIframe', 'checkLoginIframeInterval', 'flow', 'silentCheckSsoRedirectUri', 'e);
+    let options: KeycloakInitOptions = this.getProperties('onLoad', 'responseMode', 'checkLoginIframe', 'checkLoginIframeInterval', 'flow', 'silentCheckSsoRedirectUri', 'enableLogging';
 
     options.promiseType = "native";
 

--- a/addon/services/keycloak-session.ts
+++ b/addon/services/keycloak-session.ts
@@ -191,7 +191,7 @@ export default class KeycloakSessionService extends Service implements KeycloakA
       console.debug('KeycloakSessionService :: init');
     }
 
-    let options: KeycloakInitOptions = this.getProperties('onLoad', 'responseMode', 'checkLoginIframe', 'checkLoginIframeInterval', 'flow', 'silentCheckSsoRedirectUri', 'enableLogging';
+    let options: KeycloakInitOptions = this.getProperties('onLoad', 'responseMode', 'checkLoginIframe', 'checkLoginIframeInterval', 'flow', 'silentCheckSsoRedirectUri', 'enableLogging');
 
     options.promiseType = "native";
 

--- a/addon/services/keycloak-session.ts
+++ b/addon/services/keycloak-session.ts
@@ -124,6 +124,14 @@ export default class KeycloakSessionService extends Service implements KeycloakA
    * @type {String}
    */
   silentCheckSsoRedirectUri?: string;
+  
+    /**
+   * Keycloak.init() option.
+   *
+   * @property enableLogging
+   * @type {boolean}
+   */
+  enableLogging?: string;
 
   /**
    * Keycloak.login() option.
@@ -183,7 +191,7 @@ export default class KeycloakSessionService extends Service implements KeycloakA
       console.debug('KeycloakSessionService :: init');
     }
 
-    let options: KeycloakInitOptions = this.getProperties('onLoad', 'responseMode', 'checkLoginIframe', 'checkLoginIframeInterval', 'flow', 'silentCheckSsoRedirectUri');
+    let options: KeycloakInitOptions = this.getProperties('onLoad', 'responseMode', 'checkLoginIframe', 'checkLoginIframeInterval', 'flow', 'silentCheckSsoRedirectUri', 'e);
 
     options.promiseType = "native";
 

--- a/addon/services/keycloak-session.ts
+++ b/addon/services/keycloak-session.ts
@@ -118,6 +118,14 @@ export default class KeycloakSessionService extends Service implements KeycloakA
   checkLoginIframeInterval: number = 5;
 
   /**
+   * Keycloak.init() option.
+   *
+   * @property silentCheckSsoRedirectUri
+   * @type {String}
+   */
+  silentCheckSsoRedirectUri?: string;
+
+  /**
    * Keycloak.login() option.
    *
    * @property idpHint
@@ -175,7 +183,7 @@ export default class KeycloakSessionService extends Service implements KeycloakA
       console.debug('KeycloakSessionService :: init');
     }
 
-    let options: KeycloakInitOptions = this.getProperties('onLoad', 'responseMode', 'checkLoginIframe', 'checkLoginIframeInterval', 'flow');
+    let options: KeycloakInitOptions = this.getProperties('onLoad', 'responseMode', 'checkLoginIframe', 'checkLoginIframeInterval', 'flow', 'silentCheckSsoRedirectUri');
 
     options.promiseType = "native";
 


### PR DESCRIPTION
The 9.0.0 keycloak-js adapter introduced this new property. Just added it to be passed to the init function.